### PR TITLE
Adding a path to blob name

### DIFF
--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -220,8 +220,9 @@ namespace TwentyTwenty.Storage.Local
 
             try
             {
-                Directory.CreateDirectory(dir);
-                using (var file = File.Create(Path.Combine(dir, blobName)))
+                var path = Path.Combine(dir, blobName);
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                using (var file = File.Create(path))
                 {
                     await source.CopyToAsync(file);
                 }

--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -75,7 +75,7 @@ namespace TwentyTwenty.Storage.Local
             var sourcePath = Path.Combine(_basePath, sourceContainerName, sourceBlobName);
 
             var destDir = Path.Combine(_basePath, destinationContainerName);
-            Directory.CreateDirectory(destDir);
+            Directory.CreateDirectory(Path.GetDirectoryName(destDir));
 
             var destPath = Path.Combine(destDir, destinationBlobName ?? sourceBlobName);
 
@@ -197,8 +197,9 @@ namespace TwentyTwenty.Storage.Local
 
             try
             {
-                Directory.CreateDirectory(dir);
-                using (var file = File.Create(Path.Combine(dir, blobName)))
+                var path = Path.Combine(dir, blobName);
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                using (var file = File.Create(path))
                 {
                     source.CopyTo(file);
                 }


### PR DESCRIPTION
Make the relative path support in BlobName for local storage.

For example: "somePatch/test.txt"
Works for Azure, a folder will be created and a file will be created in it.
Locally - does not work.