### PR TITLE
Added fallback in case of IAM Roles on AWS

### DIFF
--- a/src/TwentyTwenty.Storage.Amazon/AmazonStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Amazon/AmazonStorageProvider.cs
@@ -58,18 +58,6 @@ namespace TwentyTwenty.Storage.Amazon
             {
                 return new BasicAWSCredentials(options.PublicKey, options.SecretKey);
             }
-
-            try
-            {
-                var env = new EnvironmentVariablesAWSCredentials();
-                env.FetchCredentials();
-                
-                return new EnvironmentVariablesAWSCredentials();
-            }
-            catch (InvalidOperationException)
-            {
-                // This exceptions happens in case there are no credentials into the environment variables Variables
-            }
             
             return FallbackCredentialsFactory.GetCredentials();
         }


### PR DESCRIPTION
If you are hosting your application into AWS cloud (ECS, EC2 ...) you don't need to add the credentials in order to work with S3 because the permission is managed by IAM Roles (here more info https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).

Right now the library work with this flow:

1) Profile
2) Key + Secret
3) Environment Variables

I've added another step (latest one) for IAM Role, so the new flow is this:

1) Profile
2) Key + Secret
3) Environment Variables
4) Fallback to CredentialFactory

Let me know if there is something you don't like or any doubt (personally I don't like the try/catch for the Environment variables but I didn't find a better solution).

Thanks