### PR TITLE
Call CreateIfNotExist only if ncessary

### DIFF
--- a/src/TwentyTwenty.Storage.Azure/AzureStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Azure/AzureStorageProvider.cs
@@ -68,8 +68,11 @@ namespace TwentyTwenty.Storage.Azure
 
             var destContainer = _blobClient.GetContainerReference(destinationContainerName);
 
-            await destContainer.CreateIfNotExistsAsync(sourceContainer.Properties.PublicAccess ?? 
+            if(!await destContainer.ExistsAsync().ConfigureAwait(false))
+            {
+                await destContainer.CreateIfNotExistsAsync(sourceContainer.Properties.PublicAccess ?? 
                 BlobContainerPublicAccessType.Off, _requestOptions, _context).ConfigureAwait(false);
+            }
 
             var destBlob = destContainer.GetBlockBlobReference(destinationBlobName ?? sourceBlobName);
 
@@ -241,7 +244,12 @@ namespace TwentyTwenty.Storage.Azure
 
             try
             {
-                var created = await container.CreateIfNotExistsAsync(security, _requestOptions, _context).ConfigureAwait(false);
+                var created = false;
+                
+                if(!await container.ExistsAsync().ConfigureAwait(false))
+                {
+                    created = await container.CreateIfNotExistsAsync(security, _requestOptions, _context).ConfigureAwait(false);
+                }
 
                 var blob = container.GetBlockBlobReference(blobName);
                 blob.Properties.ContentType = props.ContentType;                


### PR DESCRIPTION
It seems the method CreateIfNotExist of Azure Storage SDK isn't thread safe.
If I run several concurrent threads that are trying to save media into a storage, I get "**The specified container already exists**" this:

```
Error] Unable to upload the media from Storage: https://myurl........
TwentyTwenty.Storage.StorageException: Generic provider exception occurred ---> Microsoft.WindowsAzure.Storage.StorageException: The specified container already exists.
   at Microsoft.WindowsAzure.Storage.Core.Executor.Executor.ExecuteAsyncInternal[T](RESTCommand`1 cmd, IRetryPolicy policy, OperationContext operationContext, CancellationToken token)
   at Microsoft.WindowsAzure.Storage.Blob.CloudBlobContainer.CreateIfNotExistsAsync(BlobContainerPublicAccessType accessType, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
   at TwentyTwenty.Storage.Azure.AzureStorageProvider.SaveBlobStreamAsync(String containerName, String blobName, Stream source, BlobProperties properties, Boolean closeStream, Nullable`1 length)
   --- End of inner exception stack trace ---
   at TwentyTwenty.Storage.Azure.AzureStorageProvider.SaveBlobStreamAsync(String containerName, String blobName, Stream source, BlobProperties properties, Boolean closeStream, Nullable`1 length)
   at........
```

Looking on internet ([here](https://github.com/Azure/azure-sdk-for-net/issues/109#issuecomment-333512454) a reference but there are tons of articles that talk about this problems) suggest to call it only in case is necessary so I used this code:

```csharp
if(!await container.ExistsAsync().ConfigureAwait(false))
{
      created = await container.CreateIfNotExistsAsync(security, _requestOptions, _context).ConfigureAwait(false);
}
```

Hope it helps
