### PR TITLE
Local provider: store metadata file with custom metadata

### DIFF
--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -194,13 +194,7 @@ namespace TwentyTwenty.Storage.Local
         public void SaveBlobStream(string containerName, string blobName, Stream source, 
             BlobProperties properties = null, bool closeStream = true)
         {
-            var dir = Path.Combine(_basePath, containerName);
-            var path = Path.Combine(dir, blobName);
-            
-            if (!Path.GetFullPath(path).StartsWith(dir, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new UnauthorizedAccessException("Detected path traversal attempt.").ToStorageException();
-            }
+            var path = ExtractFullPathAndProtectAgainstPathTraversal(containerName, blobName);
             
             try
             {
@@ -224,13 +218,7 @@ namespace TwentyTwenty.Storage.Local
         public async Task SaveBlobStreamAsync(string containerName, string blobName, Stream source, 
             BlobProperties properties = null, bool closeStream = true, long? length = null)
         {
-            var dir = Path.Combine(_basePath, containerName);
-            var path = Path.Combine(dir, blobName);
-
-            if (!Path.GetFullPath(path).StartsWith(dir, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new UnauthorizedAccessException("Detected path traversal attempt.").ToStorageException();
-            }
+            var path = ExtractFullPathAndProtectAgainstPathTraversal(containerName, blobName);
 
             try
             {
@@ -259,6 +247,19 @@ namespace TwentyTwenty.Storage.Local
         public Task UpdateBlobPropertiesAsync(string containerName, string blobName, BlobProperties properties)
         {
             return Task.FromResult(0);
+        }
+        
+        private string ExtractFullPathAndProtectAgainstPathTraversal(string containerName, string blobName)
+        {
+            var dir = Path.Combine(_basePath, containerName);
+            var path = Path.Combine(dir, blobName);
+
+            if (!Path.GetFullPath(path).StartsWith(dir, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new UnauthorizedAccessException("Detected path traversal attempt.").ToStorageException();
+            }
+
+            return path;
         }
     }
 }

--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -98,6 +98,12 @@ namespace TwentyTwenty.Storage.Local
 
             File.Copy(sourcePath, destPath, true);
 
+            var sourceMetaPath = CreateMetadataPath(sourcePath);
+            if (File.Exists(sourceMetaPath))
+            {
+                var destMetaPath = CreateMetadataPath(destPath);
+                File.Copy(sourceMetaPath, destMetaPath, true);
+            }
             return Task.FromResult(true);
         }
 
@@ -268,7 +274,7 @@ namespace TwentyTwenty.Storage.Local
                 throw ex.ToStorageException();
             }
         }
-
+        
         public void UpdateBlobProperties(string containerName, string blobName, BlobProperties properties)
         {
             try

--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -107,7 +107,7 @@ namespace TwentyTwenty.Storage.Local
             {
                 var info = new FileInfo(path);
 
-                return new BlobDescriptor
+                var descriptor = new BlobDescriptor
                 {
                     Container = containerName,
                     ContentMD5 = "",
@@ -119,6 +119,9 @@ namespace TwentyTwenty.Storage.Local
                     Security = BlobSecurity.Private,
                     Url = info.FullName
                 };
+                MergeDescriptorWithCustomMetaIfExists(info.FullName, descriptor);
+
+                return descriptor;
             }
             catch (Exception ex)
             {
@@ -172,7 +175,7 @@ namespace TwentyTwenty.Storage.Local
 
                 foreach (var f in fileInfo)
                 {
-                    localFilesInfo.Add(new BlobDescriptor
+                    var blobDescriptor = new BlobDescriptor
                     {
                         ContentMD5 = "",
                         ETag = "",
@@ -183,7 +186,9 @@ namespace TwentyTwenty.Storage.Local
                         Name = f.Name,
                         Url = f.FullName,
                         Security = BlobSecurity.Private,
-                    });
+                    };
+                    MergeDescriptorWithCustomMetaIfExists(f.FullName, blobDescriptor);
+                    localFilesInfo.Add(blobDescriptor);
                 }
 
                 return localFilesInfo;

--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -31,7 +31,16 @@ namespace TwentyTwenty.Storage.Local
             {
                 throw new StorageException(StorageErrorCode.InvalidName.ToStorageError(), null);
             }
-            try { File.Delete(path); }
+
+            try
+            {
+                File.Delete(path);
+                var metaPath = CreateMetadataPath(path);
+                if (File.Exists(metaPath))
+                {
+                    File.Delete(metaPath);
+                }
+            }
             catch (Exception ex)
             {
                 throw ex.ToStorageException();

--- a/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Local/LocalStorageProvider.cs
@@ -221,6 +221,10 @@ namespace TwentyTwenty.Storage.Local
                 {
                     source.Dispose();
                 }
+                if (properties != default)
+                {
+                    UpdateBlobProperties(containerName, blobName, properties);
+                }
             }
             catch (Exception ex)
             {
@@ -244,6 +248,10 @@ namespace TwentyTwenty.Storage.Local
                 if (closeStream)
                 {
                     source.Dispose();
+                }
+                if (properties != default)
+                {
+                    await UpdateBlobPropertiesAsync(containerName, blobName, properties);
                 }
             }
             catch (Exception ex)

--- a/src/TwentyTwenty.Storage.Local/TwentyTwenty.Storage.Local.csproj
+++ b/src/TwentyTwenty.Storage.Local/TwentyTwenty.Storage.Local.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="../TwentyTwenty.Storage/TwentyTwenty.Storage.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+  </ItemGroup>
+
 </Project>

--- a/test/TwentyTwenty.Storage.Local.Test/CopyMoveTests.cs
+++ b/test/TwentyTwenty.Storage.Local.Test/CopyMoveTests.cs
@@ -31,6 +31,38 @@ namespace TwentyTwenty.Storage.Local.Test
             // Make sure source no longer exists
             Assert.False(File.Exists(Path.Combine(BasePath, sourceContainer, sourceName)));
         }
+        
+        [Fact]
+        public async void Test_Blob_Moved_With_Metadata()
+        {
+            var sourceContainer = GetRandomContainerName();
+            var sourceName = GenerateRandomName();
+            var destContainer = GetRandomContainerName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(sourceContainer, sourceName, data);
+
+            await _provider.UpdateBlobPropertiesAsync(sourceContainer, sourceName, new BlobProperties
+            {
+                Security = BlobSecurity.Public
+            });
+            await _provider.MoveBlobAsync(sourceContainer, sourceName, destContainer);
+
+            // Make sure destination now exists and contains original data.
+            using (var file = File.OpenRead(Path.Combine(BasePath, destContainer, sourceName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+            
+            // Make sure that destination -meta.json file exists
+            Assert.True(File.Exists(Path.Combine(BasePath, destContainer, $"{sourceName}-meta.json")));
+
+            // Make sure source no longer exists
+            Assert.False(File.Exists(Path.Combine(BasePath, sourceContainer, sourceName)));
+            
+            // Maure sure source -meta.json file no longer exists
+            Assert.False(File.Exists(Path.Combine(BasePath, sourceContainer, $"{sourceName}-meta.json")));
+        }
 
         [Fact]
         public async void Test_Blob_Moved_RelativePath()
@@ -75,6 +107,38 @@ namespace TwentyTwenty.Storage.Local.Test
 
             // Make sure source no longer exists
             Assert.False(File.Exists(Path.Combine(BasePath, sourceContainer, sourceName)));
+        }
+        
+        [Fact]
+        public async void Test_Blob_Moved_And_Renamed_With_Metadata()
+        {
+            var sourceContainer = GetRandomContainerName();
+            var sourceName = GenerateRandomName();
+            var destContainer = GetRandomContainerName();
+            var destName = GenerateRandomName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(sourceContainer, sourceName, data);
+            await _provider.UpdateBlobPropertiesAsync(sourceContainer, sourceName, new BlobProperties
+            {
+                Security = BlobSecurity.Public
+            });
+            await _provider.MoveBlobAsync(sourceContainer, sourceName, destContainer, destName);
+
+            // Make sure destination now exists and contains original data.
+            using (var file = File.OpenRead(Path.Combine(BasePath, destContainer, destName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+
+            // Make sure destination -meta.json now exists 
+            Assert.True(File.Exists(Path.Combine(BasePath, destContainer, $"{destName}-meta.json")));
+            
+            // Make sure source no longer exists
+            Assert.False(File.Exists(Path.Combine(BasePath, sourceContainer, sourceName)));
+            
+            // Make sure source -meta.json no longer exists
+            Assert.False(File.Exists(Path.Combine(BasePath, sourceContainer, $"{sourceName}-meta.json")));
         }
 
         [Fact]
@@ -124,6 +188,41 @@ namespace TwentyTwenty.Storage.Local.Test
             {
                 Assert.True(StreamEquals(data, file));
             }
+        } 
+        
+        [Fact]
+        public async void Test_Blob_Copied_With_Metadata()
+        {
+            var sourceContainer = GetRandomContainerName();
+            var sourceName = GenerateRandomName();
+            var destContainer = GetRandomContainerName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(sourceContainer, sourceName, data);
+
+            await _provider.UpdateBlobPropertiesAsync(sourceContainer, sourceName, new BlobProperties
+            {
+                Security = BlobSecurity.Public
+            });
+            await _provider.CopyBlobAsync(sourceContainer, sourceName, destContainer);
+
+            data.ToString();
+            // Make sure destination now exists and contains original data.
+            using (var file = File.OpenRead(Path.Combine(BasePath, destContainer, sourceName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+            
+            // Make sure destination -meta.json now exists 
+            Assert.True(File.Exists(Path.Combine(BasePath, destContainer, $"{sourceName}-meta.json")));
+            
+            // Make sure source still exists
+            using (var file = File.OpenRead(Path.Combine(BasePath, sourceContainer, sourceName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+            // Make sure source -meta.json still exists 
+            Assert.True(File.Exists(Path.Combine(BasePath, sourceContainer, $"{sourceName}-meta.json")));
         }
 
         [Fact]
@@ -176,6 +275,40 @@ namespace TwentyTwenty.Storage.Local.Test
             {
                 Assert.True(StreamEquals(data, file));
             }
+        }
+        
+        [Fact]
+        public async void Test_Blob_Copied_With_New_Name_With_Meta()
+        {
+            var sourceContainer = GetRandomContainerName();
+            var sourceName = GenerateRandomName();
+            var destContainer = GetRandomContainerName();
+            var destName = GenerateRandomName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(sourceContainer, sourceName, data);
+
+            await _provider.UpdateBlobPropertiesAsync(sourceContainer, sourceName, new BlobProperties
+            {
+                Security = BlobSecurity.Public
+            });
+            await _provider.CopyBlobAsync(sourceContainer, sourceName, destContainer, destName);
+
+            // Make sure destination now exists and contains original data.
+            using (var file = File.OpenRead(Path.Combine(BasePath, destContainer, destName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+            // Make sure destination -meta.json now exists
+            Assert.True(File.Exists(Path.Combine(BasePath, destContainer, $"{destName}-meta.json")));
+            
+            // Make sure source still exists
+            using (var file = File.OpenRead(Path.Combine(BasePath, sourceContainer, sourceName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+            // Make sure source -meta.json now exists
+            Assert.True(File.Exists(Path.Combine(BasePath, sourceContainer, $"{sourceName}-meta.json")));
         }
     }
 }

--- a/test/TwentyTwenty.Storage.Local.Test/CreationTestsAsync.cs
+++ b/test/TwentyTwenty.Storage.Local.Test/CreationTestsAsync.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace TwentyTwenty.Storage.Local.Test
@@ -37,6 +38,28 @@ namespace TwentyTwenty.Storage.Local.Test
             {
                 Assert.True(StreamEquals(data, file));
             }
+        }
+        
+        [Fact]
+        public async void Test_Blob_Created_With_Properties()
+        {
+            var container = GetRandomContainerName();
+            var blobName = GenerateRandomName();
+            var data = GenerateRandomBlobStream();
+
+            await _provider.SaveBlobStreamAsync(container, blobName, data, closeStream: false, properties: new BlobProperties
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    {"custom", "meta"}
+                }
+            });
+
+            using (var file = File.OpenRead(Path.Combine(BasePath, container, blobName)))
+            {
+                Assert.True(StreamEquals(data, file));
+            }
+            Assert.True(File.Exists(Path.Combine(BasePath, container, $"{blobName}-meta.json")));
         }
     }
 }

--- a/test/TwentyTwenty.Storage.Local.Test/DeletionTestsAsync.cs
+++ b/test/TwentyTwenty.Storage.Local.Test/DeletionTestsAsync.cs
@@ -36,5 +36,25 @@ namespace TwentyTwenty.Storage.Local.Test
 
             Assert.False(File.Exists(Path.Combine(BasePath, container, blobName)));
         }
+        
+        [Fact]
+        public async void Test_Blob_Deleted_Async_Also_Removes_Metadata()
+        {
+            var container = GetRandomContainerName();
+            var blobName = GenerateRandomName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(container, blobName, data);
+
+            await _provider.UpdateBlobPropertiesAsync(container, blobName, new BlobProperties
+            {
+                Security = BlobSecurity.Public
+            });
+            
+            await _provider.DeleteBlobAsync(container, blobName);
+
+            Assert.False(File.Exists(Path.Combine(BasePath, container, blobName)));
+            Assert.False(File.Exists(Path.Combine(BasePath, container, $"{blobName}-meta.json")));
+        }
     }
 }

--- a/test/TwentyTwenty.Storage.Local.Test/UpdateBlobPropertiesTests.cs
+++ b/test/TwentyTwenty.Storage.Local.Test/UpdateBlobPropertiesTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+using Xunit;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace TwentyTwenty.Storage.Local.Test
+{
+    [Trait("Category", "Local")]
+    public sealed class UpdateBlobPropertiesTests : BlobTestBase
+    {
+        public UpdateBlobPropertiesTests(StorageFixture fixture)
+            : base(fixture) { }
+
+        [Fact]
+        public async void Test_Updating_Properties_Stores_Meta_File()
+        {
+            var destinationContainer = GetRandomContainerName();
+            var destinationName = GenerateRandomName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(destinationContainer, destinationName, data);
+
+            var propertiesToStore = new BlobProperties
+            {
+                Security = BlobSecurity.Public,
+                ContentType = "application/octet-stream",
+                ContentDisposition = "inline",
+                Metadata = new Dictionary<string, string>
+                {
+                    {"custom", "data"},
+                }
+            };
+            _provider.UpdateBlobProperties(destinationContainer, destinationName, propertiesToStore);
+            
+            // Make sure that update blob properties stored the meta file
+            var metaFileName = Path.Combine(BasePath, destinationContainer, $"{destinationName}-meta.json");
+            await using var file = File.OpenRead(metaFileName);
+            using var streamReader = new StreamReader(file);
+            var fileContent = await streamReader.ReadToEndAsync();
+            var parsedBlobProperties = JsonSerializer.Deserialize<BlobProperties>(fileContent, new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter()}
+            });
+            
+            Assert.NotNull(parsedBlobProperties);
+            Assert.Equal(propertiesToStore.Security, parsedBlobProperties.Security);
+            Assert.Equal(propertiesToStore.ContentType, parsedBlobProperties.ContentType);
+            Assert.Equal(propertiesToStore.ContentDisposition, parsedBlobProperties.ContentDisposition);
+            Assert.Equal(propertiesToStore.Metadata.Count, parsedBlobProperties.Metadata.Count);
+        }
+        
+    }
+}

--- a/test/TwentyTwenty.Storage.Local.Test/UpdateBlobPropertiesTests.cs
+++ b/test/TwentyTwenty.Storage.Local.Test/UpdateBlobPropertiesTests.cs
@@ -52,5 +52,33 @@ namespace TwentyTwenty.Storage.Local.Test
             Assert.Equal(propertiesToStore.Metadata.Count, parsedBlobProperties.Metadata.Count);
         }
         
+        [Fact]
+        public async void Test_Updating_Properties_Returns_It_On_Read()
+        {
+            var destinationContainer = GetRandomContainerName();
+            var destinationName = GenerateRandomName();
+            var data = GenerateRandomBlobStream();
+
+            CreateNewFile(destinationContainer, destinationName, data);
+
+            var propertiesToStore = new BlobProperties
+            {
+                Security = BlobSecurity.Public,
+                ContentType = "application/octet-stream",
+                ContentDisposition = "inline",
+                Metadata = new Dictionary<string, string>
+                {
+                    {"custom", "data"},
+                }
+            };
+            _provider.UpdateBlobProperties(destinationContainer, destinationName, propertiesToStore);
+
+            var blob = _provider.GetBlobDescriptor(destinationContainer, destinationName);
+            
+            Assert.Equal(propertiesToStore.Security, blob.Security);
+            Assert.Equal(propertiesToStore.ContentDisposition, blob.ContentDisposition);
+            Assert.Equal(propertiesToStore.ContentType, blob.ContentType);
+            Assert.Equal(propertiesToStore.Metadata, blob.Metadata);
+        }
     }
 }


### PR DESCRIPTION
This PR will:

- **add** `System.Text.Json` for working with json data
- **update** `UpdateBlobProperties*` to store a `filename-meta.json` file with the content from passed `BlobProperties` 
- **update** `GetBlobDescriptor*` and `List` to merge "guessed" metadata with a stored metadata file
- **update** `GetBlobDescriptor*` to also return the `Metadata:dictionary<string,string>` if stored in the metadata file 
- **update** delete/copy/move operations to work on stored metadata
- **refactor** some internals to reduce code-duplication

Closes #33