### PR TITLE
Use GetObjectMetadataAsync to check for existense of a blob in AWS S3

### DIFF
--- a/src/TwentyTwenty.Storage.Amazon/AmazonStorageProvider.cs
+++ b/src/TwentyTwenty.Storage.Amazon/AmazonStorageProvider.cs
@@ -261,12 +261,20 @@ namespace TwentyTwenty.Storage.Amazon
         public async Task<bool> DoesBlobExistAsync(string containerName, string blobName)
         {
             try
-            {
-                var response = await _s3Client.ListObjectsAsync(_bucket, GenerateKeyName(containerName, blobName));
-                return response?.S3Objects?.Count > 0;
+            {                
+                await _s3Client.GetObjectMetadataAsync(_bucket, GenerateKeyName(containerName, blobName));
+                return true;
             }
             catch (AmazonS3Exception asex)
             {
+                if (string.Equals(asex.ErrorCode, "NoSuchBucket"))
+                {
+                    return false;
+                }
+                else if (string.Equals(asex.ErrorCode, "NotFound"))
+                {
+                    return false;
+                }
                 throw asex.ToStorageException();
             }
         }


### PR DESCRIPTION
This fixes a bug in the S3 version of DoesBlobExist. 

`ListObjectsAsync` will not do a exact match of the key. 

For example if there is a single blob in the container "test" called "foo.gz"

1. DoesBlobExistAsync("test", "foo.gz") will return true
2. DoesBlobExistAsync("test", "foo.g") will also return true which is wrong

On top of that it should be more efficient to try to get the metadata of a single blob compared to listing all blobs.

The code is inspired by how the same is implemented here:
https://github.com/aws/aws-sdk-net/blob/main/sdk/src/Services/S3/Custom/_bcl/IO/S3FileInfo.cs